### PR TITLE
[issue1028] Set missing C++20 flag for MSVC

### DIFF
--- a/src/cmake_modules/FastDownwardMacros.cmake
+++ b/src/cmake_modules/FastDownwardMacros.cmake
@@ -1,17 +1,21 @@
 include(CMakeParseArguments)
 
+macro(check_and_set_compiler_flag FLAG)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag( "${FLAG}" FLAG_FOUND )
+    if(NOT FLAG_FOUND)
+        message(FATAL_ERROR "${CMAKE_CXX_COMPILER} does not support ${FLAG}")
+    endif()
+    message("Flag '${FLAG}' set for '${CMAKE_CXX_COMPILER}'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
+endmacro()
+
 macro(fast_downward_set_compiler_flags)
     # Note: on CMake >= 3.0 the compiler ID of Apple-provided clang is AppleClang.
     # If we change the required CMake version from 2.8.3 to 3.0 or greater,
     # we have to fix this.
     if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-        include(CheckCXXCompilerFlag)
-        check_cxx_compiler_flag( "-std=c++20" CXX20_FOUND )
-        if(CXX20_FOUND)
-             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
-        else()
-            message(FATAL_ERROR "${CMAKE_CXX_COMPILER} does not support C++20, please use a different compiler")
-        endif()
+        check_and_set_compiler_flag( "-std=c++20" )
 
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wnon-virtual-dtor")
@@ -32,6 +36,7 @@ macro(fast_downward_set_compiler_flags)
         endif()
         set(CMAKE_CXX_FLAGS_PROFILE "-O3 -pg")
     elseif(MSVC)
+        check_and_set_compiler_flag( "/std:c++20" )
         # We force linking to be static on Windows because this makes compiling OSI simpler
         # (dynamic linking would require DLLs for OSI). On Windows this is a compiler
         # setting, not a linker setting.


### PR DESCRIPTION
Previously, we did not specify a C++ version for MSVC builds (and we do not know which default was used). Now, we set explicitly C++20 for MSVC.